### PR TITLE
Add a "From" email address to email Report task

### DIFF
--- a/Tasks/emailReportTask/config/ConfigurationProvider.ts
+++ b/Tasks/emailReportTask/config/ConfigurationProvider.ts
@@ -89,9 +89,8 @@ export class ConfigurationProvider implements IConfigurationProvider {
       throw new InputError("Email subject not set");
     }
 
-      // From Address
-      const fromAddress = tl.getInput(TaskConstants.FROMADDRESS_INPUTKEY, true);
-
+    // From Address
+    const fromAddress = tl.getInput(TaskConstants.FROMADDRESS_INPUTKEY, true);
 
     // Optional inputs
     const toAddresses = tl.getInput(TaskConstants.TOADDRESS_INPUTKEY, false);

--- a/Tasks/emailReportTask/config/ConfigurationProvider.ts
+++ b/Tasks/emailReportTask/config/ConfigurationProvider.ts
@@ -89,6 +89,10 @@ export class ConfigurationProvider implements IConfigurationProvider {
       throw new InputError("Email subject not set");
     }
 
+      // From Address
+      const fromAddress = tl.getInput(TaskConstants.FROMADDRESS_INPUTKEY, true);
+
+
     // Optional inputs
     const toAddresses = tl.getInput(TaskConstants.TOADDRESS_INPUTKEY, false);
     const ccAddresses = tl.getInput(TaskConstants.CCADDRESS_INPUTKEY, false);
@@ -101,7 +105,7 @@ export class ConfigurationProvider implements IConfigurationProvider {
 
     const defaultDomain = tl.getInput(TaskConstants.DEFAULTDOMAIN_INPUTKEY, true);
 
-    this.mailConfiguration = new MailConfiguration(mailSubject, toRecipientsConfiguration, ccRecipientsConfiguration, smtpConfig, defaultDomain);
+    this.mailConfiguration = new MailConfiguration(fromAddress, mailSubject, toRecipientsConfiguration, ccRecipientsConfiguration, smtpConfig, defaultDomain);
   }
 
   private initReportDataConfiguration(): void {

--- a/Tasks/emailReportTask/config/TaskConstants.ts
+++ b/Tasks/emailReportTask/config/TaskConstants.ts
@@ -7,6 +7,7 @@ export class TaskConstants {
   public static readonly MAXTESTFAILURESTOSHOW_INPUTKEY = "maxTestFailuresToShow";
   public static readonly GROUPTESTSUMMARYBY_INPUTKEY = "groupTestSummaryByStr";
   public static readonly INCLUDERESULTS_INPUTKEY = "includeResultsStr";
+  public static readonly FROMADDRESS_INPUTKEY = "fromAddress";
   public static readonly TOADDRESS_INPUTKEY = "toAddress";
   public static readonly CCADDRESS_INPUTKEY = "ccAddress";
   public static readonly INCLUDEINTO_INPUTKEY = "includeInToSectionStr";

--- a/Tasks/emailReportTask/config/mail/MailConfiguration.ts
+++ b/Tasks/emailReportTask/config/mail/MailConfiguration.ts
@@ -3,13 +3,15 @@ import { SmtpConfiguration } from "./SmtpConfiguration";
 
 export class MailConfiguration {
 
+  private fromAddress: string;
   private mailSubject: string;
   private toRecipientsConfig: RecipientsConfiguration;
   private ccRecipientsConfig: RecipientsConfiguration;
   private smtpConfig: SmtpConfiguration;
   private defaultDomain: string;
 
-  constructor($mailSubject: string, $toRecipientsConfig: RecipientsConfiguration, $ccRecipientsConfig: RecipientsConfiguration, $smtpConfig: SmtpConfiguration, $defaultDomain: string) {
+  constructor($fromAddress: string, $mailSubject: string, $toRecipientsConfig: RecipientsConfiguration, $ccRecipientsConfig: RecipientsConfiguration, $smtpConfig: SmtpConfiguration, $defaultDomain: string) {
+    this.fromAddress = $fromAddress;
     this.mailSubject = $mailSubject;
     this.toRecipientsConfig = $toRecipientsConfig;
     this.ccRecipientsConfig = $ccRecipientsConfig;
@@ -23,6 +25,14 @@ export class MailConfiguration {
    */
   public get $defaultDomain(): string {
     return this.defaultDomain;
+  }
+
+  /**
+      * Getter $fromAddress
+      * @return {string}
+      */
+  public get $fromAddress(): string {
+    return this.fromAddress;
   }
 
   /**

--- a/Tasks/emailReportTask/model/viewmodel/MailAddressViewModel.ts
+++ b/Tasks/emailReportTask/model/viewmodel/MailAddressViewModel.ts
@@ -15,8 +15,8 @@ export class MailAddressViewModel {
 
   private defaultDomain: string;
 
-  constructor(report: Report, mailConfig: MailConfiguration) {
-    this.from = mailConfig.$smtpConfig.$userName;
+    constructor(report: Report, mailConfig: MailConfiguration) {
+    this.from = StringUtils.isNullOrWhiteSpace(mailConfig.$fromAddress) ? mailConfig.$smtpConfig.$userName : mailConfig.$fromAddress;
     this.defaultDomain = mailConfig.$defaultDomain;
 
     console.log("computing email addresses for to section");

--- a/Tasks/emailReportTask/task.dev.json
+++ b/Tasks/emailReportTask/task.dev.json
@@ -75,6 +75,15 @@
         "DisableManageLink": "True"
       },
       "groupName": "emailConfiguration"
+    },    
+    {
+      "name": "fromAddress",
+      "type": "string",
+      "label": "From",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "Sender email address.",
+      "groupName": "emailConfiguration"
     },
     {
       "name": "toAddress",

--- a/Tasks/emailReportTask/task.prod.json
+++ b/Tasks/emailReportTask/task.prod.json
@@ -77,6 +77,15 @@
       "groupName": "emailConfiguration"
     },
     {
+      "name": "fromAddress",
+      "type": "string",
+      "label": "From",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "Sender email address.",
+      "groupName": "emailConfiguration"
+    },
+    {
       "name": "toAddress",
       "type": "string",
       "label": "To",

--- a/Tasks/emailReportTask/tests/__e_to_e_tests__/InvokeTest.ts
+++ b/Tasks/emailReportTask/tests/__e_to_e_tests__/InvokeTest.ts
@@ -46,7 +46,7 @@ export class MockConfigProvider implements IConfigurationProvider {
   }
 
   getMailConfiguration(): MailConfiguration {
-    return new MailConfiguration("[{environmentStatus}] {passPercentage} tests passed",
+    return new MailConfiguration("from@email.com", "[{environmentStatus}] {passPercentage} tests passed",
       new RecipientsConfiguration("xyz@email.com", false, false, false, false),
       new RecipientsConfiguration("", false, false, false, false),
       new SmtpConfiguration(smtpUser, smtpPassword, "smtp.live.com", true), "test.com");


### PR DESCRIPTION
Currently there is no way to specify in the configuration what do you want email's from address to be. It assumes that the SMTP's username is the from address. But for SMTP service connections where username is not an actual email adddress (does not have @ or domain), this tasks fail at runtime.

This PR will Fix #42 by giving user an optional From email configuration field. If skipped, it will defer back to using SMTP's username. This has minimal impact.