### PR TITLE
fix path for xslt on different OS

### DIFF
--- a/Extensions/emailReportTask/Tasks/emailReportTask/emailReportTaskV2/htmlreport/HTMLReportCreator.ts
+++ b/Extensions/emailReportTask/Tasks/emailReportTask/emailReportTaskV2/htmlreport/HTMLReportCreator.ts
@@ -3,6 +3,7 @@ import { IHTMLReportCreator } from './IHTMLReportCreator';
 import { Report } from '../model/Report';
 import { ReportConfiguration } from '../config/ReportConfiguration';
 const fs = require("fs");
+const path = require("path");
 const o2x = require('object-to-xml');
 const xsltProcessor = require("xslt-processor");
 const { xmlParse, xsltProcess } = xsltProcessor;
@@ -12,7 +13,8 @@ export class HTMLReportCreator implements IHTMLReportCreator {
   createHtmlReport(report: Report, reportConfiguration: ReportConfiguration): string {
     const currDir = __dirname;
     console.log(`CurrentDir: ${currDir}`);
-    var xsltTemplatePath = `${currDir}\\EmailTemplate.xslt`;
+    // var xsltTemplatePath = `${currDir}\\EmailTemplate.xslt`;
+    var xsltTemplatePath = path.join(currDir, "EmailTemplate.xslt");
     console.log("Loading Email Template: " + xsltTemplatePath);
 
     // Create a view model object before serialize to xml


### PR DESCRIPTION
This pull request includes changes to the `HTMLReportCreator.ts` file to improve the handling of file paths and ensure compatibility across different operating systems.

Codebase improvements:

* [`Extensions/emailReportTask/Tasks/emailReportTask/emailReportTaskV2/htmlreport/HTMLReportCreator.ts`](diffhunk://#diff-a2dac1a4250d6c5069e0bce93c1bac726032785da4dc8d10b60d3404507edfb3R6): Added the `path` module to handle file paths more robustly.
* [`Extensions/emailReportTask/Tasks/emailReportTask/emailReportTaskV2/htmlreport/HTMLReportCreator.ts`](diffhunk://#diff-a2dac1a4250d6c5069e0bce93c1bac726032785da4dc8d10b60d3404507edfb3L15-R17): Modified the assignment of `xsltTemplatePath` to use `path.join` for better cross-platform compatibility.