### PR TITLE
Updated Node Version in PullRequest Insights task

### DIFF
--- a/Extensions/pullRequestInsightsTask/dataModels/Branch.ts
+++ b/Extensions/pullRequestInsightsTask/dataModels/Branch.ts
@@ -1,6 +1,6 @@
 import { AbstractPipeline } from "./AbstractPipeline";
 import tl = require("azure-pipelines-task-lib/task");
-import stats from "stats-lite";
+import * as stats from "stats-lite";
 import { PipelineTask } from "./PipelineTask";
 import { BranchStatus } from "./BranchStatus";
 

--- a/Extensions/pullRequestInsightsTask/dataModels/PullRequest.ts
+++ b/Extensions/pullRequestInsightsTask/dataModels/PullRequest.ts
@@ -1,7 +1,7 @@
 import * as azureGitInterfaces from "azure-devops-node-api/interfaces/GitInterfaces";
 import { AbstractAzureApi } from "../dataProviders/AbstractAzureApi.js";
 import tl = require("azure-pipelines-task-lib/task");
-import commentProperties from "../resources/service_comment_properties.json";
+import * as commentProperties from "../resources/service_comment_properties.json";
 import { ServiceComment } from "../models/ServiceComment.js";
 
 export class PullRequest {

--- a/Extensions/pullRequestInsightsTask/dataProviders/AbstractAzureApi.ts
+++ b/Extensions/pullRequestInsightsTask/dataProviders/AbstractAzureApi.ts
@@ -23,7 +23,7 @@ export abstract class AbstractAzureApi {
    * Fetches current pipeline which task is running in, either build or release depending on AzureApi subclass
    * @param data Object containing variables set by environment and task configurations
    */
-  public abstract async getCurrentPipeline(
+  public abstract getCurrentPipeline(
     data: PipelineData
   ): Promise<AbstractPipeline>;
 
@@ -34,7 +34,7 @@ export abstract class AbstractAzureApi {
    * @param maxNumber Maximum number of pipelines to return
    * @param branchName Name of branch pipelines are running on
    */
-  public abstract async getMostRecentPipelinesOfCurrentType(
+  public abstract getMostRecentPipelinesOfCurrentType(
     project: string,
     currentPipeline: AbstractPipeline,
     maxNumber: number,
@@ -102,7 +102,7 @@ export abstract class AbstractAzureApi {
    * @param project Name of project from which to fetch pipelines
    * @param definitionId Id of definition to fetch
    */
-  public abstract async getDefinition(
+  public abstract getDefinition(
     project: string,
     definitionId: number
   ): Promise<any>;

--- a/Extensions/pullRequestInsightsTask/index.ts
+++ b/Extensions/pullRequestInsightsTask/index.ts
@@ -1,6 +1,6 @@
 import tl = require("azure-pipelines-task-lib/task");
 import { EnvironmentConfigurations } from "./config/EnvironmentConfigurations";
-import messages from "./resources/user_messages.json";
+import * as messages from "./resources/user_messages.json";
 import "./utils/StringExtensions";
 import { PipelineData } from "./config/PipelineData";
 import { TaskInsights } from "./TaskInsights";

--- a/Extensions/pullRequestInsightsTask/models/FailureTable.ts
+++ b/Extensions/pullRequestInsightsTask/models/FailureTable.ts
@@ -1,5 +1,5 @@
 import { AbstractTable } from "./AbstractTable";
-import messages from "../resources/user_messages.json";
+import * as messages from "../resources/user_messages.json";
 import { Branch } from "../dataModels/Branch";
 import { PipelineTask } from "../dataModels/PipelineTask";
 import { AbstractPipeline } from "../dataModels/AbstractPipeline";

--- a/Extensions/pullRequestInsightsTask/models/LongRunningValidationsTable.ts
+++ b/Extensions/pullRequestInsightsTask/models/LongRunningValidationsTable.ts
@@ -1,5 +1,5 @@
 import tl = require("azure-pipelines-task-lib/task");
-import messages from "../resources/user_messages.json";
+import * as messages from "../resources/user_messages.json";
 import { AbstractPipeline } from "../dataModels/AbstractPipeline";
 import { PipelineTask } from "../dataModels/PipelineTask";
 import { AbstractTable } from "./AbstractTable";
@@ -9,6 +9,11 @@ import { Branch } from "../dataModels/Branch";
  * This class represents a table within a comment meant to display data about task regression when the
  * current pipeline has tasks that run over a threshold time
  */
+declare global {
+  interface String {
+    format(...args: any[]): string;
+  }
+}
 export class LongRunningValidationsTable extends AbstractTable {
   private static readonly TIME_LABELS: Map<() => number, string> = new Map([
     [Date.prototype.getUTCHours, "h"],

--- a/Extensions/pullRequestInsightsTask/models/ServiceComment.ts
+++ b/Extensions/pullRequestInsightsTask/models/ServiceComment.ts
@@ -3,7 +3,7 @@ import * as azureGitInterfaces from "azure-devops-node-api/interfaces/GitInterfa
 import { AbstractTable } from "./AbstractTable";
 import { AbstractPipeline } from "../dataModels/AbstractPipeline";
 import { TableFactory } from "../factories/TableFactory";
-import messages from "../resources/user_messages.json";
+import * as messages from "../resources/user_messages.json";
 import { TaskInsights } from "../TaskInsights";
 import { Branch } from "../dataModels/Branch";
 import { PipelineTask } from "../dataModels/PipelineTask";

--- a/Extensions/pullRequestInsightsTask/task.dev.json
+++ b/Extensions/pullRequestInsightsTask/task.dev.json
@@ -5,11 +5,11 @@
     "description": "Gets insight into pull requests",
     "helpMarkDown": "",
     "category": "Utility",
-    "author": "Leah Schwartz",
+    "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 18
+        "Patch": 30
     },
     "instanceNameFormat": "PR Insights",
     "inputs": [
@@ -59,7 +59,7 @@
         }
     ],
     "execution": {
-        "Node": {
+        "Node16": {
             "target": "index.js"
         }
     }

--- a/Extensions/pullRequestInsightsTask/task.json
+++ b/Extensions/pullRequestInsightsTask/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 18
+        "Patch": 30
     },
     "instanceNameFormat": "PR Insights",
     "inputs": [
@@ -59,7 +59,7 @@
         }
     ],
     "execution": {
-        "Node": {
+        "Node16": {
             "target": "index.js"
         }
     }

--- a/Extensions/pullRequestInsightsTask/task.prod.json
+++ b/Extensions/pullRequestInsightsTask/task.prod.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 18
+        "Patch": 19
     },
     "instanceNameFormat": "PR Insights",
     "inputs": [
@@ -59,7 +59,7 @@
         }
     ],
     "execution": {
-        "Node": {
+        "Node16": {
             "target": "index.js"
         }
     }

--- a/Extensions/pullRequestInsightsTask/tsconfig.json
+++ b/Extensions/pullRequestInsightsTask/tsconfig.json
@@ -11,5 +11,6 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all 		imports. Implies 'allowSyntheticDefaultImports'. */
     "outDir": "../../dist/pullRequestInsightsExtension/pullRequestInsightsTask",
+    "lib": ["es2018", "es2015", "dom"],
   }
 }

--- a/Extensions/pullRequestInsightsTask/vss-extension.json
+++ b/Extensions/pullRequestInsightsTask/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "PullRequestInsightsExtension",
   "name": "Pull Request Insights Extension",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "publisher": "epsteam",
   "targets": [
     {

--- a/Extensions/pullRequestInsightsTask/vss-extensionPPE.json
+++ b/Extensions/pullRequestInsightsTask/vss-extensionPPE.json
@@ -1,0 +1,40 @@
+{
+    "manifestVersion": 1,
+    "id": "PullRequestInsightsExtensionPP",
+    "name": "Pull Request Insights Extension Pre-Production",
+    "version": "0.1.32",
+    "publisher": "epsteam",
+    "targets": [
+      {
+        "id": "Microsoft.VisualStudio.Services"
+      }
+    ],
+    "description": "Extension to look at pull requests and provide insights",
+    "categories": ["Azure Pipelines"],
+    "icons": {},
+    "tags": [],
+    "scopes": [],
+    "files": [
+      {
+        "path": "pullRequestInsightsTask"
+      }
+    ],
+    "content": {
+      "details": {
+        "path": "README.md"
+      },
+      "license": {
+        "path": "LICENSE"
+      }
+    },
+    "contributions": [
+      {
+        "id": "c4ffd380-3a3b-4fa6-b02a-00ee18afe1f5",
+        "type": "ms.vss-distributed-task.task",
+        "targets": ["ms.vss-distributed-task.tasks"],
+        "properties": {
+          "name": "pullRequestInsightsTask"
+        }
+      }
+    ]
+  }


### PR DESCRIPTION
We observed below warning while using PR insights task. 

`[warning]Task 'PR Insights' version 0 (PRInsights@0) is dependent on a Node version (6) that is end-of-life. Contact the extension owner for an updated version of the task. Task maintainers should review Node upgrade guidance: https://aka.ms/node-runner-guidance`

Hence updated the node version to use Node16 and other files which produced some errors while building the task. We were able to build the task successfully with these code changes, tested in Pre-prod and then deployed it into Prod. We don't see any issues so far, and the task is working fine as expected.

